### PR TITLE
docs: add Windows theme directory to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@
 
 ## Usage
 
-1. Copy/move the flavor(s) of your choice from [`themes/`](./themes/) to your [Warp theme directory](https://docs.warp.dev/appearance/custom-themes) (`$HOME/.warp/themes` on macOS or `${XDG_DATA_HOME:-$HOME/.local/share}/warp-terminal/themes` on Linux).
+1. Copy/move the flavor(s) of your choice from [`themes/`](./themes/) to your [Warp theme directory](https://docs.warp.dev/appearance/custom-themes).
+   -  `$HOME/.warp/themes` on macOS.
+   -  `${XDG_DATA_HOME:-$HOME/.local/share}/warp-terminal/themes` on Linux.
+   -  `%AppData%\warp\Warp\data\themes` on Windows.
 2. Restart Warp to load the new themes.
 3. Open **Settings** > **Themes** and select your flavor.
 


### PR DESCRIPTION
This PR adds the Windows theme to the [Usage](https://github.com/catppuccin/warp?tab=readme-ov-file#usage) instructions in the README, now that Warp launched for Windows.

Before:
1. Copy/move the flavor(s) of your choice from [`themes/`](./themes/) to your [Warp theme directory](https://docs.warp.dev/appearance/custom-themes) (`$HOME/.warp/themes` on macOS or `${XDG_DATA_HOME:-$HOME/.local/share}/warp-terminal/themes` on Linux).
2. Restart Warp to load the new themes.
3. Open **Settings** > **Themes** and select your flavor.

After:

1. Copy/move the flavor(s) of your choice from [`themes/`](./themes/) to your [Warp theme directory](https://docs.warp.dev/appearance/custom-themes).
   -  `$HOME/.warp/themes` on macOS.
   -  `${XDG_DATA_HOME:-$HOME/.local/share}/warp-terminal/themes` on Linux.
   -  `%AppData%\warp\Warp\data\themes` on Windows.
2. Restart Warp to load the new themes.
3. Open **Settings** > **Themes** and select your flavor.