### PR TITLE
fix: include theme names & rebuild themes

### DIFF
--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -21,3 +21,4 @@ terminal_colors:
     magenta: '#f4b8e4'
     cyan: '#81c8be'
     white: '#a5adce'
+name: Catppuccin Frappé

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -21,3 +21,4 @@ terminal_colors:
     magenta: '#ea76cb'
     cyan: '#179299'
     white: '#bcc0cc'
+name: Catppuccin Latte

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -21,3 +21,4 @@ terminal_colors:
     magenta: '#f5bde6'
     cyan: '#8bd5ca'
     white: '#a5adcb'
+name: Catppuccin Macchiato

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -21,3 +21,4 @@ terminal_colors:
     magenta: '#f5c2e7'
     cyan: '#94e2d5'
     white: '#a6adc8'
+name: Catppuccin Mocha

--- a/warp.tera
+++ b/warp.tera
@@ -4,7 +4,7 @@ whiskers:
   version: "2.2.0"
   matrix:
     - flavor
-  filename: "themes/catppuccin_{{ flavor.identifier }}.yml"
+  filename: "themes/catppuccin-{{ flavor.identifier }}.yaml"
 ---
 background: '#{{ base.hex }}'
 accent: '#{{ flavor.colors[accent].hex }}'
@@ -29,3 +29,4 @@ terminal_colors:
     magenta: '#{{ pink.hex }}'
     cyan: '#{{ teal.hex }}'
     white: '#{{ if(cond=flavor.dark, t=subtext0.hex, f=surface1.hex) }}'
+name: Catppuccin {{ flavor.name }}


### PR DESCRIPTION
Theme names were required for them to appear in Warp. I amended warp.tera to include this and rebuilt the themes.